### PR TITLE
Get Windows Build Working

### DIFF
--- a/cmake/onnxruntime_providers_iree.cmake
+++ b/cmake/onnxruntime_providers_iree.cmake
@@ -28,23 +28,24 @@ target_link_libraries(onnxruntime_providers_iree PRIVATE
   onnx
   protobuf::libprotobuf
 )
+if ( CMAKE_COMPILER_IS_GNUCC )
+  target_compile_options(
+    onnxruntime_providers_iree PRIVATE
+    # IREE's runtime headers are written in the C style and need some tweaks.
+    -Wno-missing-field-initializers
+    # We're not going to fix this.
+    -Wno-unused-function
+  )
 
-target_compile_options(
-  onnxruntime_providers_iree PRIVATE
-  # IREE's runtime headers are written in the C style and need some tweaks.
-  -Wno-missing-field-initializers
-  # We're not going to fix this.
-  -Wno-unused-function
-)
-
-# Torch-mlir warnings disable warnings on external sources.
-# TODO: Fix these at the source.
-set_source_files_properties(
-  ${onnxruntime_providers_iree_jit_compiler_srcs}
-  PROPERTIES
-    COMPILE_FLAGS
-      "-Wno-unused-parameter -Wno-shorten-64-to-32"
-)
+  # Torch-mlir warnings disable warnings on external sources.
+  # TODO: Fix these at the source.
+  set_source_files_properties(
+    ${onnxruntime_providers_iree_jit_compiler_srcs}
+    PROPERTIES
+      COMPILE_FLAGS
+        "-Wno-unused-parameter -Wno-shorten-64-to-32"
+  )
+endif()
 
 # Note that these will fail if IREECompilerConfig.cmake and IREERuntime.cmake are not on the search path.
 # There are multiple ways to ensure this, but typically (as will be called out in the error message):

--- a/onnxruntime/core/providers/iree/README.md
+++ b/onnxruntime/core/providers/iree/README.md
@@ -58,6 +58,51 @@ Explanations:
 Once the build has been initially done, you can work in the `build/Linux/RelWithDebInfo` directory if that is more
 comfortable.
 
+## Building on Windows
+
+Instructions for setting up IREE-EP on windows is similar to linux.
+
+1. Make sure you have the appropriate C++ development environment setup. E.g. install Visual Studio Build Tools 2022 and start "x64 Native Tools Command Prompt for Visual Studio 2022" as administrator to get access to a compiler and linker. It is useful to check that you have registry edit permissions (try running regedit), since successful initialization of this environment requires such access. If you don't already have cmake and ninja, install them with winget (or your preferred method). Once you have the development environment setup, it is helpful to run
+```powershell
+powershell
+Set-ExecutionPolicy Bypass -Scope Process
+cd <your development directory>
+```
+
+2. Build IREE from source. After cloning the repository and updating submodules, you can use a build command like the following to get an IREE build that will work with IREE-EP for llvm-cpu:
+```powershell
+cmake -S . -B build -G "Ninja" -DCMAKE_BUILD_TYPE=Release `
+   -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DIREE_ENABLE_ASSERTIONS=ON `
+   -DLLVM_ENABLE_ASSERTIONS=ON -UIREE_DEFAULT_CPU_LLVM_TARGETS `
+   -DIREE_BUILD_SAMPLES=OFF -DIREE_BUILD_PYTHON_BINDINGS=OFF `
+   -DIREE_BUILD_BINDINGS_TFLITE=OFF -DIREE_HAL_DRIVER_DEFAULTS=OFF `
+   -DIREE_HAL_DRIVER_LOCAL_SYNC=ON -DIREE_HAL_DRIVER_LOCAL_TASK=ON `
+   -DIREE_TARGET_BACKEND_DEFAULTS=OFF -DIREE_TARGET_BACKEND_LLVM_CPU=ON `
+   -DIREE_INPUT_TOSA=OFF -DIREE_INPUT_STABLEHLO=OFF -DIREE_ENABLE_CPUINFO=OFF
+```
+Importantly, `-DIREE_ENABLE_CPUINFO=OFF` is required to work properly with IREE-EP.
+
+3. Add iree-compile and iree-run-module to PATH:
+```powershell
+$env:path += ";<abs path to IREE build dir>\tools"
+```
+This is an important step, otherwise onnxruntime executable files won't be able to find `ireeCompiler.dll` and will just silently fail.
+
+4. Clone this repo and run the following build command from your onnxruntime directory:
+```powershell
+.\build.bat --config=RelWithDebInfo --cmake_generator=Ninja `
+     --build_shared_lib `
+     --compile_no_warning_as_error `
+     --parallel `
+     --use_iree `
+     --cmake_extra_defines "IREECompiler_DIR=C:/z/iree/build/lib/cmake/IREE" `
+     --cmake_extra_defines "IREERuntime_DIR=C:/z/iree/build/lib/cmake/IREE" `
+     --use_full_protobuf `
+     --enable_symbolic_shape_infer_tests `
+     --update `
+     --build
+```
+
 ## Build from released IREE
 
 IMPORTANT: This will currently not work with stock IREE builds because of the cpuinfo issue listed above.
@@ -82,6 +127,7 @@ packaging==23.2
 protobuf==4.25.1
 sympy==1.12
 ```
+Note: the following commands also work with windows powershell, but you'll need to change the forward to back slashes in file paths, and use backtick instead of backslash to seperate a command into multiple lines.
 
 ```
 # From build dir.

--- a/onnxruntime/core/providers/iree/compiler/jit_compiler.cc
+++ b/onnxruntime/core/providers/iree/compiler/jit_compiler.cc
@@ -109,7 +109,7 @@ CompilerInvocation::CompilerInvocation(CompilerSession& session, const char* mod
         CompilerInvocation* self = static_cast<CompilerInvocation*>(userData);
         self->diagnostics.emplace_back(DiagnosticRecord{severity, std::string(message, messageSize)});
         // VLOG it.
-        VLOGS(session.logger, INFO) << self->diagnostics.back().ToString();
+        VLOGS(self->session.logger, INFO) << self->diagnostics.back().ToString();
       },
       static_cast<void*>(this));
 
@@ -120,7 +120,7 @@ CompilerInvocation::CompilerInvocation(CompilerSession& session, const char* mod
         auto* self = static_cast<CompilerInvocation*>(userdata);
         // TODO: We need to have better configuration for how to dump such reproducers.
         auto output_path = std::filesystem::temp_directory_path() / "ort_iree_reproducer.mlir";
-        std::string output_path_str = output_path;
+        std::string output_path_str = output_path.string();
         LOGS(self->session.logger, ERROR) << "IREE compiler crash. Writing reproducer to: " << output_path_str;
         return ireeCompilerOutputOpenFile(output_path_str.c_str(), out_output);
       },


### PR DESCRIPTION
This PR modifies the cmake options to conditionally exclude some `-Wno-something` flags which cause problems with the windows build, makes some small changes to `jit_compiler.cc` to avoid other compiler errors on windows, and adds instructions for building on windows to the README.md.