### PR TITLE
[IREE-EP] Register IREE EP in OnnxRT's python bindings.

### DIFF
--- a/onnxruntime/python/onnxruntime_pybind_schema.cc
+++ b/onnxruntime/python/onnxruntime_pybind_schema.cc
@@ -52,6 +52,9 @@ void addGlobalSchemaFunctions(pybind11::module& m) {
 #ifdef USE_VITISAI
             onnxruntime::VitisAIProviderFactoryCreator::Create(ProviderOptions{}),
 #endif
+#ifdef USE_IREE
+            onnxruntime::IREEProviderFactoryCreator::Create(ProviderOptions{}),
+#endif
 #ifdef USE_ACL
             onnxruntime::ACLProviderFactoryCreator::Create(0),
 #endif

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -963,6 +963,16 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
     return onnxruntime::VitisAIProviderFactoryCreator::Create(vitis_option_map)
         ->CreateProvider();
 #endif
+  } else if (type == kIreeExecutionProvider) {
+#if USE_IREE
+    const auto &it = provider_options_map.find(type);
+    ProviderOptions iree_option_map = ProviderOptions{};
+    if (it != provider_options_map.end()) {
+      iree_option_map = it->second;
+    }
+    return onnxruntime::IREEProviderFactoryCreator::Create(iree_option_map)
+        ->CreateProvider();
+#endif
   } else if (type == kAclExecutionProvider) {
 #ifdef USE_ACL
     return onnxruntime::ACLProviderFactoryCreator::Create(

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -794,6 +794,8 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
       if ((reinterpret_cast<OnnxModelInfo*>(model_info.get()))->HasDomain(ONNX_NAMESPACE::AI_ONNX_TRAINING_DOMAIN) ||
           (reinterpret_cast<OnnxModelInfo*>(model_info.get()))->HasDomain(ONNX_NAMESPACE::AI_ONNX_PREVIEW_TRAINING_DOMAIN)) {
         fprintf(stderr, "Skip test case:: %s %s\n", ToUTF8String(test_case_name_in_log).c_str(), " as it has training domain");
+        // TODO: Revisit this commented line once we rebase our fork to sync with upstream main.
+        // This return statement should not ideally be commented out, and is here just as a temporary workaround.
         // return true;
       }
 #endif

--- a/onnxruntime/test/onnx/TestCase.cc
+++ b/onnxruntime/test/onnx/TestCase.cc
@@ -794,7 +794,7 @@ void LoadTests(const std::vector<std::basic_string<PATH_CHAR_TYPE>>& input_paths
       if ((reinterpret_cast<OnnxModelInfo*>(model_info.get()))->HasDomain(ONNX_NAMESPACE::AI_ONNX_TRAINING_DOMAIN) ||
           (reinterpret_cast<OnnxModelInfo*>(model_info.get()))->HasDomain(ONNX_NAMESPACE::AI_ONNX_PREVIEW_TRAINING_DOMAIN)) {
         fprintf(stderr, "Skip test case:: %s %s\n", ToUTF8String(test_case_name_in_log).c_str(), " as it has training domain");
-        return true;
+        // return true;
       }
 #endif
 

--- a/onnxruntime/test/perftest/command_args_parser.cc
+++ b/onnxruntime/test/perftest/command_args_parser.cc
@@ -217,6 +217,8 @@ static bool ParseDimensionOverride(std::basic_string<ORTCHAR_T>& dim_identifier,
           test_config.machine_config.provider_type_name = onnxruntime::kXnnpackExecutionProvider;
         } else if (!CompareCString(optarg, ORT_TSTR("vitisai"))) {
           test_config.machine_config.provider_type_name = onnxruntime::kVitisAIExecutionProvider;
+        } else if (!CompareCString(optarg, ORT_TSTR("iree"))) {
+          test_config.machine_config.provider_type_name = onnxruntime::kIreeExecutionProvider;
         } else {
           return false;
         }

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -544,7 +544,7 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
 #else
     ORT_THROW("VitisAI is not supported in this build\n");
 #endif
-  } else if (!provider_name.empty() && provider_name != onnxruntime::kCpuExecutionProvider) {
+  } else if (!provider_name.empty() && provider_name != onnxruntime::kCpuExecutionProvider && provider_name != onnxruntime::kIreeExecutionProvider) {
     ORT_THROW("This backend is not included in perf test runner.\n");
   }
 

--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -544,6 +544,8 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
 #else
     ORT_THROW("VitisAI is not supported in this build\n");
 #endif
+    // TODO: We need to register the IREE EP here just as the other EPs have done, and not just use a check like this.
+    // Once the EP is functional, this check should be removed from here, and a complete implementation should be added above.
   } else if (!provider_name.empty() && provider_name != onnxruntime::kCpuExecutionProvider && provider_name != onnxruntime::kIreeExecutionProvider) {
     ORT_THROW("This backend is not included in perf test runner.\n");
   }


### PR DESCRIPTION
Registers `IreeExecutionProvider` in the Python bindings for `onnxruntime`.
A warning is still issued, saying that `IreeExecutionProvider` is not in the list of known providers, but can be safely ignored.