### PR TITLE
[IREE EP] Fix ElementsAttr iteration error from MLIR.

### DIFF
--- a/onnxruntime/core/providers/get_execution_providers.cc
+++ b/onnxruntime/core/providers/get_execution_providers.cc
@@ -188,6 +188,14 @@ constexpr ProviderInfo kProvidersInPriorityOrder[] =
             false,
 #endif
         },
+        {
+            kIreeExecutionProvider,
+#ifdef USE_IREE
+            true,
+#else
+            false,
+#endif
+        },
         {kCpuExecutionProvider, true},  // kCpuExecutionProvider is always last
 };
 

--- a/onnxruntime/core/providers/iree/compiler/jit_compiler.cc
+++ b/onnxruntime/core/providers/iree/compiler/jit_compiler.cc
@@ -194,8 +194,9 @@ common::Status CompilerInvocation::ImportSubgraph(const onnxruntime::GraphViewer
   }
 
   if (torch_mlir_onnx::failed(imp.ImportAll())) {
-    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, "Failed to import nodes", ": ",
-        model_info.error_message(), ConsumeDiagnostics());
+    return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, "Failed to import nodes",
+                           ": ", model_info.error_message(),
+                           ConsumeDiagnostics());
   }
 
   // Verify the function at the point of import because we have better diagnostics.

--- a/onnxruntime/core/providers/iree/compiler/jit_compiler.cc
+++ b/onnxruntime/core/providers/iree/compiler/jit_compiler.cc
@@ -159,7 +159,7 @@ common::Status CompilerInvocation::ImportSubgraph(const onnxruntime::GraphViewer
   }
 
   ONNX_NAMESPACE::GraphProto graph_proto;
-  GraphViewerToProto(graph_view, graph_proto, true, true);
+  GraphViewerToProto(graph_view, graph_proto, false, false);
   // LOGS(session.logger, INFO) << "  full graph: " << graph_proto.DebugString();
 
   // Set up for subgraph import.

--- a/onnxruntime/core/providers/iree/compiler/jit_compiler.cc
+++ b/onnxruntime/core/providers/iree/compiler/jit_compiler.cc
@@ -5,6 +5,7 @@
 // (which require a pre-compilation step).
 
 #include "core/providers/iree/compiler/jit_compiler.h"
+#include "core/graph/graph_proto_serializer.h"
 #include "core/providers/iree/compiler/torch-mlir-import-onnx/OnnxImporter.h"
 #include "mlir-c/BuiltinAttributes.h"
 
@@ -140,7 +141,7 @@ CompilerInvocation::~CompilerInvocation() {
   ireeCompilerInvocationDestroy(inv);
 }
 
-common::Status CompilerInvocation::ImportSubgraph(const onnxruntime::GraphViewer& graph_view, const std::string& func_name) {
+common::Status CompilerInvocation::ImportSubgraph(const ONNX_NAMESPACE::ModelProto &model_proto, const onnxruntime::GraphViewer& graph_view, const std::string& func_name) {
   // Note that we just use a synthetic top-level ModelProto and forego main
   // graph initialization. Since we are operating on a subgraph view, we
   // initialize from the backing Graph proto but initialize it ourselves.
@@ -159,11 +160,12 @@ common::Status CompilerInvocation::ImportSubgraph(const onnxruntime::GraphViewer
 
   // Unforgivably sharp edge: There is a ToGraphProto() that returns a value and another that returns a reference.
   // And they differ by const-ness. We need to make sure we get the reference, obviously, so we assign it explicitly.
-  const ONNX_NAMESPACE::GraphProto& graph_proto = graph_view.GetGraph().ToGraphProto();
+  ONNX_NAMESPACE::GraphProto graph_proto;
+  GraphViewerToProto(graph_view, graph_proto, true, true);
   // LOGS(session.logger, INFO) << "  full graph: " << graph_proto.DebugString();
 
   // Set up for subgraph import.
-  torch_mlir_onnx::GraphInfo subgraph_info(model_info, graph_proto);
+  torch_mlir_onnx::GraphInfo subgraph_info(graph_view, model_info, graph_proto);
   if (torch_mlir_onnx::failed(subgraph_info.Initialize())) {
     return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, model_info.error_message());
   }
@@ -201,6 +203,7 @@ common::Status CompilerInvocation::ImportSubgraph(const onnxruntime::GraphViewer
   for (size_t i = 0; i < node_indices.size(); ++i) {
     graph_view.GetNode(node_indices[i])->ToProto(nodes[i]);
   }
+  imp.ImportNoneNode();
   for (const auto& node : nodes) {
     if (torch_mlir_onnx::failed(imp.ImportNode(node))) {
       return ORT_MAKE_STATUS(ONNXRUNTIME, INVALID_GRAPH, "Failed to import node '", node.name(), "': ",

--- a/onnxruntime/core/providers/iree/compiler/jit_compiler.h
+++ b/onnxruntime/core/providers/iree/compiler/jit_compiler.h
@@ -81,7 +81,7 @@ struct CompilerInvocation {
   ~CompilerInvocation();
 
   // Imports a subgraph as a public function.
-  common::Status ImportSubgraph(const ONNX_NAMESPACE::ModelProto &model_proto, const onnxruntime::GraphViewer& graph_view, const std::string& func_name);
+  common::Status ImportSubgraph(const onnxruntime::GraphViewer& graph_view, const std::string& func_name);
 
   // Compile and output a VMFB.
   common::Status CompileAndOutputVMFB(iree_compiler_output_t* output);

--- a/onnxruntime/core/providers/iree/compiler/jit_compiler.h
+++ b/onnxruntime/core/providers/iree/compiler/jit_compiler.h
@@ -81,7 +81,7 @@ struct CompilerInvocation {
   ~CompilerInvocation();
 
   // Imports a subgraph as a public function.
-  common::Status ImportSubgraph(const onnxruntime::GraphViewer& graph_view, const std::string& func_name);
+  common::Status ImportSubgraph(const ONNX_NAMESPACE::ModelProto &model_proto, const onnxruntime::GraphViewer& graph_view, const std::string& func_name);
 
   // Compile and output a VMFB.
   common::Status CompileAndOutputVMFB(iree_compiler_output_t* output);

--- a/onnxruntime/core/providers/iree/compiler/torch-mlir-import-onnx/OnnxImporter.cpp
+++ b/onnxruntime/core/providers/iree/compiler/torch-mlir-import-onnx/OnnxImporter.cpp
@@ -228,23 +228,6 @@ Status GraphInfo::Initialize() {
 }
 
 const onnx::TypeProto *GraphInfo::FindTypeProtoForName(std::string_view name) {
-  // Node outputs don't typically have type information, but shape inference
-  // will associate them in the value_info. If not there, it may be a
-  // graph output, which must have type information.
-#if 0
-  {
-    auto it = value_info_map_.find(name);
-    if (it != value_info_map_.end()) {
-      return &it->second.type();
-    }
-  }
-  {
-    auto it = output_map_.find(name);
-    if (it != output_map_.end()) {
-      return &it->second.type();
-    }
-  }
-#endif
   return graph_viewer_.GetNodeArg(std::string{name})->TypeAsProto();
 }
 

--- a/onnxruntime/core/providers/iree/compiler/torch-mlir-import-onnx/OnnxImporter.h
+++ b/onnxruntime/core/providers/iree/compiler/torch-mlir-import-onnx/OnnxImporter.h
@@ -21,8 +21,8 @@
 #include "mlir-c/IR.h"
 #include "onnx/onnx_pb.h"
 
-#include <optional>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <unordered_map>
 
@@ -66,7 +66,8 @@ static inline bool failed(Status status) { return !status.is_success(); }
 // Accounting for a GraphProto.
 class GraphInfo {
 public:
-  GraphInfo(const onnxruntime::GraphViewer &gv, ModelInfo &model_info, const onnx::GraphProto &graph_proto)
+  GraphInfo(const onnxruntime::GraphViewer &gv, ModelInfo &model_info,
+            const onnx::GraphProto &graph_proto)
       : graph_viewer_(gv), model_info_(model_info), graph_proto_(graph_proto) {}
   ModelInfo &model_info() { return model_info_; }
   const onnx::GraphProto &graph_proto() { return graph_proto_; }

--- a/onnxruntime/core/providers/iree/compiler/torch-mlir-import-onnx/OnnxImporter.h
+++ b/onnxruntime/core/providers/iree/compiler/torch-mlir-import-onnx/OnnxImporter.h
@@ -217,13 +217,13 @@ public:
   void ImportNoneNode();
   /// Import nodes one at a time. Must complete with a call to FinalizeGraph.
   Status ImportNode(const onnx::NodeProto &node);
+  Status ImportInitializer(const onnx::TensorProto &initializer);
   Status FinalizeGraph();
 
   void DebugDumpModule();
 
 private:
   void PopulateGraphAttrs(MlirOperation container_op);
-  Status ImportInitializer(const onnx::TensorProto &initializer);
   MlirAttribute ImportGeneralAttribute(const onnx::AttributeProto &onnx_attr);
 
   // Special-form nodes.

--- a/onnxruntime/core/providers/iree/compiler/torch-mlir-import-onnx/OnnxImporter.h
+++ b/onnxruntime/core/providers/iree/compiler/torch-mlir-import-onnx/OnnxImporter.h
@@ -22,6 +22,7 @@
 #include "onnx/onnx_pb.h"
 
 #include <optional>
+#include <memory>
 #include <string_view>
 #include <unordered_map>
 

--- a/onnxruntime/core/providers/iree/iree_execution_provider.cc
+++ b/onnxruntime/core/providers/iree/iree_execution_provider.cc
@@ -7,9 +7,11 @@
 #include "core/framework/compute_capability.h"
 #include "core/framework/fallback_cpu_capability.h"
 #include "core/framework/kernel_registry.h"
+#include "core/graph/graph_proto_serializer.h"
 #include "core/graph/graph_utils.h"
 #include "core/graph/graph_viewer.h"
 
+#include "core/graph/model.h"
 #include "core/providers/iree/compiler/jit_compiler.h"
 
 #include <cassert>
@@ -122,8 +124,18 @@ common::Status IREEExecutionProvider::Compile(const std::vector<FusedNodeAndGrap
   for (auto& fused_node_graph : fused_nodes_and_graphs) {
     const GraphViewer& graph_view = fused_node_graph.filtered_graph;
     const Node& fused_node = fused_node_graph.fused_node;
-    const std::string& func_name = fused_node.Name();
-    ORT_RETURN_IF_ERROR(inv.ImportSubgraph(graph_view, func_name));
+    const std::string func_name = fused_node.Name();
+    Model model(graph_view.Name(), true, ModelMetaData(), PathString(),
+                IOnnxRuntimeOpSchemaRegistryList(), graph_view.DomainToVersionMap(),
+                std::vector<ONNX_NAMESPACE::FunctionProto>(), *GetLogger());
+    ONNX_NAMESPACE::ModelProto model_proto = model.ToProto();
+
+    GraphViewerToProto(graph_view, *model_proto.mutable_graph(), true, true);
+    auto opset = model_proto.add_opset_import();
+    opset->set_domain(kOnnxDomain);
+    opset->set_version(graph_view.DomainToVersionMap().at(kOnnxDomain));
+
+    ORT_RETURN_IF_ERROR(inv.ImportSubgraph(model_proto, graph_view, func_name));
     // The fully qualified name is the {module_name}.{func_name}. This is what we look up at
     // runtime.
     std::string fq_name(module_name);

--- a/onnxruntime/core/providers/iree/iree_execution_provider.cc
+++ b/onnxruntime/core/providers/iree/iree_execution_provider.cc
@@ -76,10 +76,6 @@ std::vector<std::unique_ptr<ComputeCapability>> IREEExecutionProvider::GetCapabi
     inputs.push_back(nodeArgPtr->Name());
   }
 
-  for (auto& name : required_initializers) {
-    inputs.push_back(name);
-  }
-
   for (auto& nodeArgPtr : graph_viewer.GetOutputs()) {
     outputs.push_back(nodeArgPtr->Name());
   }

--- a/onnxruntime/core/providers/shared_library/provider_api.h
+++ b/onnxruntime/core/providers/shared_library/provider_api.h
@@ -274,6 +274,7 @@ constexpr const char* kMIGraphXExecutionProvider = "MIGraphXExecutionProvider";
 constexpr const char* kQnnExecutionProvider = "QNNExecutionProvider";
 constexpr const char* kCpuExecutionProvider = "CPUExecutionProvider";
 constexpr const char* kAzureExecutionProvider = "AzureExecutionProvider";
+constexpr const char* kIreeExecutionProvider = "IreeExecutionProvider";
 
 template <typename T>
 using IAllocatorUniquePtr = std::unique_ptr<T, std::function<void(T*)>>;

--- a/onnxruntime/python/onnxruntime_pybind_state.cc
+++ b/onnxruntime/python/onnxruntime_pybind_state.cc
@@ -1141,7 +1141,7 @@ std::unique_ptr<IExecutionProvider> CreateExecutionProviderInstance(
 #endif
   } else if (type == kIreeExecutionProvider) {
 #if USE_IREE
-    const auto &it = provider_options_map.find(type);
+    const auto& it = provider_options_map.find(type);
     ProviderOptions iree_option_map = ProviderOptions{};
     if (it != provider_options_map.end()) {
       iree_option_map = it->second;


### PR DESCRIPTION
Before this patch, many models would get an error from MLIR (ElementsAttr does not provide iteration facilities for type <type>).

This patch now enables importing initializers on demand, and disables serializing them in GraphProto obtained from onnxruntime::GraphView. The importer now generates correct IR for ONNX models, with correct number of inputs/outputs.

