### PR TITLE
Revert "[IREE EP][Importer] Fix IR import for onnx.ConstantOfShape"

### DIFF
--- a/onnxruntime/core/providers/iree/compiler/torch-mlir-import-onnx/OnnxImporter.h
+++ b/onnxruntime/core/providers/iree/compiler/torch-mlir-import-onnx/OnnxImporter.h
@@ -93,10 +93,6 @@ public:
     return nullptr;
   }
 
-  std::unordered_map<std::string_view, const onnx::ValueInfoProto &> &
-  value_info_map() {
-    return value_info_map_;
-  }
   std::vector<const onnx::ValueInfoProto *> &inputs() { return inputs_; }
   std::unordered_map<std::string_view, const onnx::ValueInfoProto &> &
   input_map() {


### PR DESCRIPTION
Reverts nod-ai/onnxruntime#11
This PR introduces regression in the Densenet_int8 model, so reverting this one. Onnxrt does not have "ConstantOfShape" in the graph but includes it in initializers list, which is what we have to figure out and get a fix.