### PR TITLE
[perftest] Enable perf tests for IREE EP

### DIFF
--- a/onnxruntime/test/perftest/ort_test_session.cc
+++ b/onnxruntime/test/perftest/ort_test_session.cc
@@ -399,6 +399,12 @@ select from 'TF8', 'TF16', 'UINT8', 'FLOAT', 'ITENSOR'. \n)");
 #else
     ORT_THROW("NNAPI is not supported in this build\n");
 #endif
+  } else if (provider_name_ == onnxruntime::kIreeExecutionProvider) {
+#ifdef USE_IREE
+    session_options.AppendExecutionProvider("IREE");
+#else
+    ORT_THROW("IREE is not supported in this build\n");
+#endif
   } else if (provider_name_ == onnxruntime::kVSINPUExecutionProvider) {
 #ifdef USE_VSINPU
     Ort::ThrowOnError(OrtSessionOptionsAppendExecutionProvider_VSINPU(session_options));


### PR DESCRIPTION
This patch adds perf testing capability for the IREE EP.

Now, the IREE EP can be profiled for performance through the use of the `onnxruntime_perf_test` utility by passing in `-e iree` as a flag.

